### PR TITLE
Use dedicated mender_deb_version fixture for deb package.

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -51,13 +51,13 @@ def setup_tester_ssh_connection(setup_test_container):
     yield new_tester_ssh_connection(setup_test_container)
 
 @pytest.fixture(scope="class")
-def setup_mender_configured(setup_test_container, setup_tester_ssh_connection, mender_version):
+def setup_mender_configured(setup_test_container, setup_tester_ssh_connection, mender_deb_version):
     if setup_tester_ssh_connection.run("test -x /usr/bin/mender", warn=True).exited == 0:
         # If mender is already present, do nothing.
         return
 
     url = ("https://d1b0l86ne08fsf.cloudfront.net/%s/dist-packages/debian/armhf/mender-client_%s-1_armhf.deb"
-           % (mender_version, mender_version))
+           % (mender_deb_version, mender_deb_version))
     filename = os.path.basename(url)
     c = requests.get(url, stream=True)
     with open(filename, "wb") as fd:


### PR DESCRIPTION
It may differ from the compiled mender version.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>