### PR TITLE
Disable publishing the Docker image in Docker Hub

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -63,11 +63,14 @@ publish:build:master:
   stage: publish
   dependencies:
     - build
+  services:
+    - docker:dind
   script:
-    - docker load -i image.tar
-    - export COMMIT_TAG="$CI_COMMIT_REF_NAME"_"$CI_COMMIT_SHA";
-    - docker tag $DOCKER_REPOSITORY:pr $DOCKER_REPOSITORY:$COMMIT_TAG;
-    - docker push $DOCKER_REPOSITORY:$COMMIT_TAG;
+    - echo "publishing image to docker hub"
+    # - docker load -i image.tar
+    # - export COMMIT_TAG="$CI_COMMIT_REF_NAME"_"$CI_COMMIT_SHA";
+    # - docker tag $DOCKER_REPOSITORY:pr $DOCKER_REPOSITORY:$COMMIT_TAG;
+    # - docker push $DOCKER_REPOSITORY:$COMMIT_TAG;
   only:
     - master
   tags:


### PR DESCRIPTION
As it is done in the rest of the pipelines for now...

Changelog: None

Signed-off-by: Lluis Campos <lluis.campos@northern.tech>