### PR TITLE
Switch curl wget downloads

### DIFF
--- a/docker/docker-files-raspbian/prepare-raspbian-img.sh
+++ b/docker/docker-files-raspbian/prepare-raspbian-img.sh
@@ -60,11 +60,11 @@ else
 fi
 
 echo "##### Donwloading and extracting..."
-curl -sLfO ${raspbian_url}
+wget -q ${raspbian_url}
 unzip ${raspbian_filename_zip}
 rm ${raspbian_filename_zip}
-curl -sLfO https://raw.githubusercontent.com/dhruvvyas90/qemu-rpi-kernel/master/kernel-qemu-4.14.79-stretch
-curl -sLfO https://raw.githubusercontent.com/dhruvvyas90/qemu-rpi-kernel/master/versatile-pb.dtb
+wget -q https://raw.githubusercontent.com/dhruvvyas90/qemu-rpi-kernel/master/kernel-qemu-4.14.79-stretch
+wget -q https://raw.githubusercontent.com/dhruvvyas90/qemu-rpi-kernel/master/versatile-pb.dtb
 
 echo "##### Preparing image for tests..."
 boot_start=$(fdisk -l ${raspbian_filename_img} | grep Linux | tr -s ' ' | cut -d ' ' -f2)

--- a/docker/docker-files-raspbian/prepare-raspbian-img.sh
+++ b/docker/docker-files-raspbian/prepare-raspbian-img.sh
@@ -60,11 +60,11 @@ else
 fi
 
 echo "##### Donwloading and extracting..."
-wget -q ${raspbian_url}
+wget -q -nc ${raspbian_url}
 unzip ${raspbian_filename_zip}
 rm ${raspbian_filename_zip}
-wget -q https://raw.githubusercontent.com/dhruvvyas90/qemu-rpi-kernel/master/kernel-qemu-4.14.79-stretch
-wget -q https://raw.githubusercontent.com/dhruvvyas90/qemu-rpi-kernel/master/versatile-pb.dtb
+wget -q -nc https://raw.githubusercontent.com/dhruvvyas90/qemu-rpi-kernel/master/kernel-qemu-4.14.79-stretch
+wget -q -nc https://raw.githubusercontent.com/dhruvvyas90/qemu-rpi-kernel/master/versatile-pb.dtb
 
 echo "##### Preparing image for tests..."
 boot_start=$(fdisk -l ${raspbian_filename_img} | grep Linux | tr -s ' ' | cut -d ' ' -f2)


### PR DESCRIPTION
Change ported (and amended) from #7 

```
commit fe169c75e9f8d5e1127fb9d487f9610b77cceda7
Author: Manuel Zedel <manuel.zedel@northern.tech>
Date:   Tue Aug 27 11:40:46 2019 +0200

    switched to wget to download raspbian due to curl security
    this is necessary as raspberrypi.org seems to use a too short tls key,
    which is not tolerable for curl but for wget
    Changelog: None
    
    Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>

commit 208718f1a5a2d684663ba79fba636f9e90fcb03a
Author: Lluis Campos <lluis.campos@northern.tech>
Date:   Wed Aug 28 11:09:39 2019 +0200

    Add --no-clobber option to wget downloads
    
    So that we don't make copies of the downloaded raspbian files
    
    Changelog: None
    
    Signed-off-by: Lluis Campos <lluis.campos@northern.tech>
```