### PR TITLE
Minor improvements while working on MEN-2599

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -19,6 +19,7 @@ import requests
 import subprocess
 import time
 import os.path
+import logging
 
 from fabric import Connection
 
@@ -32,13 +33,18 @@ def setup_test_container(request, setup_test_container_props, mender_version):
     if setup_test_container_props.append_mender_version:
         image = "%s:%s" % (image, mender_version)
 
-    output = subprocess.check_output("docker run --rm --network host -tid %s" % image, shell=True)
+    cmd = "docker run --rm --network host -tid %s" % image
+    logging.debug("setup_test_container: %s", cmd)
+    output = subprocess.check_output(cmd, shell=True)
+
     global docker_container_id
     docker_container_id = output.decode("utf-8").split("\n")[0]
     setup_test_container_props.container_id = docker_container_id
 
     def finalizer():
-        subprocess.check_output("docker stop {}".format(docker_container_id), shell=True)
+        cmd = "docker stop {}".format(docker_container_id)
+        logging.debug("setup_test_container: %s", cmd)
+        subprocess.check_output(cmd, shell=True)
     request.addfinalizer(finalizer)
 
     ready = wait_for_container_boot(docker_container_id)

--- a/helpers.py
+++ b/helpers.py
@@ -37,6 +37,12 @@ def put(conn, file, key_filename=None, local_path=".", remote_path="."):
     conn.local("scp %s -C -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -P %s %s %s@%s:%s" %
           (key_arg, conn.port, os.path.join(local_path, file), conn.user, conn.host, remote_path))
 
+def run(conn, command, key_filename=None, warn=False):
+    key_arg = _prepare_key_arg(key_filename)
+    result = conn.local("ssh %s -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=60 -p %s %s@%s %s" %
+                        (key_arg, conn.port, conn.user, conn.host, command), warn=warn)
+    return result
+
 class PortForward:
     user = None
     host = None

--- a/helpers.py
+++ b/helpers.py
@@ -19,6 +19,7 @@ import signal
 import stat
 import subprocess
 import time
+import logging
 from fabric import Config
 from fabric import Connection
 from paramiko import SSHException
@@ -34,13 +35,15 @@ def _prepare_key_arg(key_filename):
 
 def put(conn, file, key_filename=None, local_path=".", remote_path="."):
     key_arg = _prepare_key_arg(key_filename)
-    conn.local("scp %s -C -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -P %s %s %s@%s:%s" %
-          (key_arg, conn.port, os.path.join(local_path, file), conn.user, conn.host, remote_path))
+    cmd = "scp %s -C -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -P %s %s %s@%s:%s" % (key_arg, conn.port, os.path.join(local_path, file), conn.user, conn.host, remote_path)
+    logging.debug(cmd)
+    conn.local(cmd)
 
 def run(conn, command, key_filename=None, warn=False):
     key_arg = _prepare_key_arg(key_filename)
-    result = conn.local("ssh %s -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=60 -p %s %s@%s %s" %
-                        (key_arg, conn.port, conn.user, conn.host, command), warn=warn)
+    cmd = "ssh %s -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=60 -p %s %s@%s %s" % (key_arg, conn.port, conn.user, conn.host, command)
+    logging.debug(cmd)
+    result = conn.local(cmd, warn=warn)
     return result
 
 class PortForward:


### PR DESCRIPTION
```
commit 511c4e9f32899344e19c7ed813a45dae267f5135
Author: Lluis Campos <lluis.campos@northern.tech>
Date:   Thu Sep 5 15:28:17 2019 +0200

    Implement alternative 'run' method using system's ssh
    
    For where we cannot use Fabric, same as above 'put' method
    
    Changelog: None
    
    Signed-off-by: Lluis Campos <lluis.campos@northern.tech>

commit 3edec1e9022c46057ac6b60ccc741eace875411a
Author: Lluis Campos <lluis.campos@northern.tech>
Date:   Mon Sep 9 11:16:32 2019 +0200

    Add some debug level logging to helpers and fixtures
    
    Changelog: None
    
    Signed-off-by: Lluis Campos <lluis.campos@northern.tech>
```