### PR TITLE
MEN-3601: Install Mender deb package missing dependencies in fixture

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,6 +16,8 @@ include:
     file: '.gitlab-ci-check-commits-signoffs.yml'
   - project: 'Northern.tech/Mender/mendertesting'
     file: '.gitlab-ci-github-status-updates.yml'
+  - project: 'Northern.tech/Mender/mendertesting'
+    file: '.gitlab-ci-check-python3-format.yml'
 
 build_prep:
   stage: build_prep

--- a/conftest.py
+++ b/conftest.py
@@ -86,8 +86,10 @@ def setup_mender_configured(
             filename,
             key_filename=setup_test_container.key_filename,
         )
+        # Install deb package and missing dependencies
         setup_tester_ssh_connection.sudo(
-            "DEBIAN_FRONTEND=noninteractive dpkg -i %s" % filename
+            "DEBIAN_FRONTEND=noninteractive dpkg -i %s || sudo apt-get -f -y install"
+            % filename
         )
     finally:
         os.remove(filename)

--- a/container_props.py
+++ b/container_props.py
@@ -15,6 +15,7 @@
 
 import os
 
+
 class ContainerProps:
     image_name = None
     append_mender_version = None
@@ -28,8 +29,16 @@ class ContainerProps:
     # Will be set once the container is running
     container_id = None
 
-    def __init__(self, image_name, append_mender_version=False, device_type=None, key_filename=None,
-                 user="root", port=8822, qemu_ip="10.0.2.15"):
+    def __init__(
+        self,
+        image_name,
+        append_mender_version=False,
+        device_type=None,
+        key_filename=None,
+        user="root",
+        port=8822,
+        qemu_ip="10.0.2.15",
+    ):
         self.image_name = image_name
         self.append_mender_version = append_mender_version
         self.device_type = device_type
@@ -38,10 +47,19 @@ class ContainerProps:
         self.port = port
         self.qemu_ip = qemu_ip
 
-MenderTestRaspbian = ContainerProps(image_name="mendersoftware/mender-test-containers:raspbian_latest",
-                                    device_type="raspberrypi3",
-                                    key_filename=os.path.join(os.path.dirname(os.path.realpath(__file__)), "docker/ssh-keys/key"),
-                                    user="pi")
-MenderTestQemux86_64 = ContainerProps(image_name="mendersoftware/mender-client-qemu",
-                                      append_mender_version=True,
-                                      key_filename=os.path.join(os.path.dirname(os.path.realpath(__file__)), "docker/ssh-keys/key"))
+
+MenderTestRaspbian = ContainerProps(
+    image_name="mendersoftware/mender-test-containers:raspbian_latest",
+    device_type="raspberrypi3",
+    key_filename=os.path.join(
+        os.path.dirname(os.path.realpath(__file__)), "docker/ssh-keys/key"
+    ),
+    user="pi",
+)
+MenderTestQemux86_64 = ContainerProps(
+    image_name="mendersoftware/mender-client-qemu",
+    append_mender_version=True,
+    key_filename=os.path.join(
+        os.path.dirname(os.path.realpath(__file__)), "docker/ssh-keys/key"
+    ),
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[tool.black]
+target-version = ['py38']
+include = '\.py$'
+exclude = '''
+(
+  /(
+      \.eggs         # exclude a few common directories
+    | \.git
+    | \.mypy_cache
+    | .*\.venv
+    | .*venv
+    | _build
+    | build
+    | dist
+  )/
+)
+'''


### PR DESCRIPTION
-  [Python black] Enable style enforcement and update files

- MEN-3601: Install Mender deb package missing dependencies in fixture
This should fix integration tests at mender-binary-delta repo.

Follow-up from https://github.com/mendersoftware/mender-dist-packages/pull/30