### PR TITLE
conftest: func-scoped versions of existing fixtures

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -26,8 +26,7 @@ from fabric import Connection
 from .helpers import *
 
 
-@pytest.fixture(scope="class")
-def setup_test_container(request, setup_test_container_props, mender_version):
+def do_setup_test_container(request, setup_test_container_props, mender_version):
     # This should be parametrized in the mother project.
     image = setup_test_container_props.image_name
 
@@ -56,8 +55,23 @@ def setup_test_container(request, setup_test_container_props, mender_version):
 
 
 @pytest.fixture(scope="class")
+def setup_test_container(request, setup_test_container_props, mender_version):
+    return do_setup_test_container(request, setup_test_container_props, mender_version)
+
+
+@pytest.fixture(scope="function")
+def setup_test_container_f(request, setup_test_container_props, mender_version):
+    return do_setup_test_container(request, setup_test_container_props, mender_version)
+
+
+@pytest.fixture(scope="class")
 def setup_tester_ssh_connection(setup_test_container):
     yield new_tester_ssh_connection(setup_test_container)
+
+
+@pytest.fixture(scope="function")
+def setup_tester_ssh_connection_f(setup_test_container_f):
+    yield new_tester_ssh_connection(setup_test_container_f)
 
 
 @pytest.fixture(scope="class")


### PR DESCRIPTION
existing fixtures allow creating a test container per test class.
this means one container, and its complete state, is shared across
all functions in a test class.

this is ok-ish if that's the idea - test funcs must be ordered in a
way that respects modifications made in previous funcs. this can get
out of control quickly if new funcs are added to a class.

a more convenient pattern is to have the container created per test
func - this way each scenario starts with a clean slate, so:

extend the set of fixtures with their function-scoped versions.

Issues: 4150

changelog: none

Signed-off-by: Marcin Chalczynski <m.chalczynski@gmail.com>