### PR TITLE
python-requirements: revert 'major' dependabot upgrades

### DIFF
--- a/backend-acceptance-testing/requirements-py3.txt
+++ b/backend-acceptance-testing/requirements-py3.txt
@@ -1,8 +1,8 @@
-bravado==11.0.2
+bravado==9.2.2
 crypto
 cryptography==3.4.6
 flask
-minio==7.0.2
+minio==5.0.6
 pluggy==0.13.1
 pycrypto
 pymongo==3.11.3


### PR DESCRIPTION
the bravado upgrade is problematic as it breaks the
library API - and existing acceptance tests (for sure
in deviceauth, possibly everywhere).

the upgrade was from 9.x.x to 11.x.x so that's expected.
however, trying to revert to 9.3.2 (highest 9.x.x version) still
results in the same problems.
we must revert to 9.2.2 to make them go away.

just to be safe, do the same with the minio upgrade.

changelog: none

Signed-off-by: Marcin Chalczynski <m.chalczynski@gmail.com>