### PR TITLE
paramiko: set look_for_keys and allow_agent to False

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -128,6 +128,8 @@ def new_tester_ssh_connection(setup_test_container):
             "timeout": 60,
             "banner_timeout": 60,
             "auth_timeout": 60,
+            "allow_agent": False,
+            "look_for_keys": False,
         },
     ) as conn:
 


### PR DESCRIPTION
Following changes from integration test framework. See:
* https://github.com/mendersoftware/integration/pull/1333
* https://github.com/mendersoftware/integration/pull/1336