### PR TITLE
Set the non-conflicting jsonchema version (<4.0) in backend acceptance tests requirements file

### DIFF
--- a/backend-acceptance-testing/requirements-py3.txt
+++ b/backend-acceptance-testing/requirements-py3.txt
@@ -2,6 +2,7 @@ bravado==9.2.2
 crypto
 cryptography==35.0.0
 flask
+jsonschema<4.0
 minio==5.0.6
 pluggy==1.0.0
 pycrypto


### PR DESCRIPTION
Set the non-conflicting jsonchema version (<4.0) in backend acceptance tests requirements file

Changelog: None

Signed-off-by: Maciej Tomczuk <maciej.tomczuk@northern.tech>