### PR TITLE
Add docker to backend acceptance test image python requirements

### DIFF
--- a/backend-acceptance-testing/Dockerfile.backend-tests
+++ b/backend-acceptance-testing/Dockerfile.backend-tests
@@ -1,4 +1,4 @@
-FROM python:3-slim
+FROM python:3.10-slim
 # Install musl runtime support to be able to execute the dynamically linked deployments binary
 # See https://wiki.debian.org/musl
 RUN apt-get -qq update && \

--- a/backend-acceptance-testing/requirements-py3.txt
+++ b/backend-acceptance-testing/requirements-py3.txt
@@ -1,6 +1,7 @@
 bravado==9.2.2
 crypto
 cryptography==36.0.1
+docker>=5.0
 flask
 jsonschema<4.0
 minio==5.0.6

--- a/backend-acceptance-testing/requirements-py3.txt
+++ b/backend-acceptance-testing/requirements-py3.txt
@@ -1,7 +1,7 @@
 bravado==9.2.2
 crypto
 cryptography==36.0.1
-docker>=5.0
+docker==5.0.3
 flask
 jsonschema<4.0
 minio==5.0.6


### PR DESCRIPTION
Required for acceptance tests CLI coverage.