### PR TITLE
chore(redo): Add redo dependency to allow retries in backend test containers

### DIFF
--- a/backend-acceptance-testing/requirements-py3.txt
+++ b/backend-acceptance-testing/requirements-py3.txt
@@ -12,6 +12,7 @@ pytest-ordering==0.6
 pytest==7.1.1
 pyyaml
 redis==4.1.4
+redo==2.0.4
 requests
 stripe
 tornado


### PR DESCRIPTION
chore(redo): Add redo dependency to allow retries in backend test containers

Changelog: None

Signed-off-by: Maciej Tomczuk <maciej.tomczuk@northern.tech>