### PR TITLE
chore(semver): Add semver dependency to use in backend acceptance tests

### DIFF
--- a/backend-acceptance-testing/requirements-py3.txt
+++ b/backend-acceptance-testing/requirements-py3.txt
@@ -14,6 +14,7 @@ pyyaml
 redis==4.3.2
 redo==2.0.4
 requests
+semver==2.13.0
 stripe
 tornado
 twisted


### PR DESCRIPTION
chore(semver): Add semver dependency to use in backend acceptance tests

Changelog: None
Ticket: MEN-5667
Signed-off-by: Maciej Tomczuk <maciej.tomczuk@northern.tech>