### PR TITLE
ci(scp): Fall back to the legacy SCP protocol

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -38,7 +38,7 @@ def _prepare_key_arg(key_filename):
 def put(conn, file, key_filename=None, local_path=".", remote_path="."):
     key_arg = _prepare_key_arg(key_filename)
     cmd = (
-        "scp %s -C -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -P %s %s %s@%s:%s"
+        "scp %s -C -O -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -P %s %s %s@%s:%s"
         % (
             key_arg,
             conn.port,


### PR DESCRIPTION
New versions of the scp program uses the SFTP protocol by
default. However SFTP is not installed in our qemu hosts, and hence
this does not work.

The fix is simple. Fall back to the legacy functionality. The SCP
protocol, though aged, works just fine for our needs.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>