### PR TITLE
build: Revert from `needs` back to `dependencies` for publication.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -417,7 +417,7 @@ publish:docker-multiplatform-buildx:
 
 publish:mender-dist-packages-image:
   extends: .template:publish
-  needs:
+  dependencies:
     # NOTE: We should depend on each of the jobs individually with:
     # - "build:mender-dist-packages-image: [${DISTRO}, ${RELEASE}, ${ARCH}]"
     # However GitLab does not seem to expand these variables on a dependencies


### PR DESCRIPTION
The comment already explains why, the keyword was changed unintentionally after the comment was added.

Ticket: QA-655