### PR TITLE
chore: switch to the newer APT repo for Kubernetes

### DIFF
--- a/backend-integration-testing/Dockerfile
+++ b/backend-integration-testing/Dockerfile
@@ -1,10 +1,13 @@
 FROM python:3.11-bullseye
 
+ARG K8S_VERSION=1.29
+
 RUN apt-get -y -qq update && apt-get -qq -y install docker.io libzbar0 apt-transport-https gnupg2 && \
-    curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
-    echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | tee -a /etc/apt/sources.list.d/kubernetes.list && \
+    mkdir -p /etc/apt/keyrings && \
+    curl -fsSL https://pkgs.k8s.io/core:/stable:/v${K8S_VERSION}/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg && \
+    echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v${K8S_VERSION}/deb/ /" | tee -a /etc/apt/sources.list.d/kubernetes.list && \
     apt-get update && \
-    apt-get install -y awscli kubectl=1.23.7-00 && \
+    apt-get install -y awscli kubectl && \
     curl -o /usr/bin/aws-iam-authenticator https://amazon-eks.s3.us-west-2.amazonaws.com/1.17.9/2020-08-04/bin/linux/amd64/aws-iam-authenticator && \
     chmod 755 /usr/bin/aws-iam-authenticator && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
The old one was deprecated back in 2023 and stopped working; install the kubectl version 1.29 using the current official APT repo.

Changelog: None
Ticket: None