### PR TITLE
ci: Fix "blocked" pipelines by refactoring the manual job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -212,14 +212,11 @@ build:aws-k8s-pipeline-toolbox:
         --push
         aws-k8s-toolbox
 
-build:mender-dist-packages-image:
+.build:mender-dist-packages-image:
   tags:
     - hetzner-amd-beefy-privileged
   stage: build
   needs: []
-  rules:
-    - if: $CI_COMMIT_BRANCH == "master"
-    - when: manual
   image: docker:git
   services:
     - docker:dind
@@ -236,6 +233,15 @@ build:mender-dist-packages-image:
          --arch ${ARCH}
          --ci-pipeline-id ${CI_PIPELINE_ID}
   parallel: !reference [.mender-dist-packages-image-matrix, parallel]
+
+build:mender-dist-packages-image:
+  rules:
+    - if: $CI_COMMIT_BRANCH == "master"
+  extends: .build:mender-dist-packages-image
+
+build:mender-dist-packages-image:manual:
+  when: manual
+  extends: .build:mender-dist-packages-image
 
 build:docker-multiplatform-buildx:
   tags:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -219,7 +219,6 @@ build:mender-dist-packages-image:
   needs: []
   rules:
     - if: $CI_COMMIT_BRANCH == "master"
-    - if: $CI_COMMIT_BRANCH == "feature-armhf-native"
     - when: manual
   image: docker:git
   services:
@@ -430,7 +429,6 @@ publish:mender-dist-packages-image:
     - "build:mender-dist-packages-image: [debian, bullseye, amd64]"
   rules:
     - if: $CI_COMMIT_BRANCH == "master"
-    - if: $CI_COMMIT_BRANCH == "feature-armhf-native"
   script:
     - CONTAINER_TAG=mender-dist-packages-builder-${DISTRO}-${RELEASE}-${ARCH}
     - *tag_n_push_to_gitlab_registry


### PR DESCRIPTION
 It seems like `rules:manual` is not treated the same was as top-level `manual`. In the former, the pipeline expects the job to be run at some point (hence in never finishes) while the latter is treated as an optional job.
    
Refactor the pipeline code to accommodate for this.