### PR TITLE
chore: remove fabric dependency

### DIFF
--- a/backend-integration-testing/requirements-py3.txt
+++ b/backend-integration-testing/requirements-py3.txt
@@ -7,7 +7,6 @@ chardet==5.2.0
 cryptography==42.0.5
 docker==7.0.0
 execnet==2.1.1
-fabric==3.2.2
 filelock==3.13.4
 idna==3.7
 iniconfig==2.0.0


### PR DESCRIPTION
Follow up from QA-650 where we removed Fabric dependency in the integration repo. This allows mender-configure-module to be updated, since it doesn't have Fabric, and it uses this repo as a submodule.

Ticket: QA-666