### PR TITLE
test(backend-acceptance): Add boto3 to Python requirements

### DIFF
--- a/backend-acceptance-testing/requirements-py3.txt
+++ b/backend-acceptance-testing/requirements-py3.txt
@@ -1,4 +1,5 @@
 bravado==9.2.2
+boto3==1.34.101
 crypto
 cryptography==42.0.5
 docker==7.0.0


### PR DESCRIPTION
The deployments acceptance tests are the boto3 (S3 API) client instead of relying on the vendor specific `minio` dependency.