### PR TITLE
chore: Roll back requests to 2.31.0

### DIFF
--- a/backend-acceptance-testing/requirements-py3.txt
+++ b/backend-acceptance-testing/requirements-py3.txt
@@ -15,7 +15,7 @@ pytest==8.2.0
 pyyaml
 redis==5.0.4
 redo==2.0.4
-requests
+requests==2.31.0
 semver==3.0.2
 stripe
 tornado


### PR DESCRIPTION
requests 2.32.0 breaks docker.