### PR TITLE
QA-666: Revert "remove fabric dependency"

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-# Copyright 2024 Northern.tech AS
+# Copyright 2022 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -21,57 +21,9 @@ import stat
 import subprocess
 import time
 
-
-class Result:
-    def __init__(self, stdout, stderr, exited):
-        self.stdout = stdout
-        self.stderr = stderr
-        self.exited = exited
-        self.return_code = exited
-
-
-class Connection:
-    def __init__(self, host, user, port, connect_timeout):
-        self.host = host
-        self.user = user
-        self.port = port
-        self.connect_timeout = connect_timeout
-
-    def __enter__(self):
-        return self
-
-    def run(self, command, warn=False, hide=True, echo=False, popen=False):
-        if echo:
-            print(command)
-
-        if popen:
-            return subprocess.Popen(command)
-        else:
-            try:
-                proc = subprocess.run(
-                    command, check=not warn, capture_output=True, shell=True
-                )
-                returncode = proc.returncode
-
-            except subprocess.CalledProcessError as e:
-                returncode = e.returncode
-                if returncode != 255:
-                    raise
-
-            if returncode == 255:
-                raise ConnectionError(f"Could not connect using command '{command}'")
-
-            stdout = proc.stdout.decode()
-            stderr = proc.stderr.decode()
-
-            if not hide:
-                print(stdout)
-                print(stderr)
-
-            return Result(stdout, stderr, returncode)
-
-    def __exit__(self, arg1, arg2, arg3):
-        pass
+from fabric import Config
+from fabric import Connection
+from paramiko import SSHException
 
 
 def _prepare_key_arg(key_filename):
@@ -98,7 +50,7 @@ def put(conn, file, key_filename=None, local_path=".", remote_path="."):
         )
     )
     logging.debug(cmd)
-    conn.run(cmd)
+    conn.local(cmd)
 
 
 def run(conn, command, key_filename=None, warn=False):
@@ -108,7 +60,7 @@ def run(conn, command, key_filename=None, warn=False):
         % (key_arg, conn.port, conn.user, conn.host, command)
     )
     logging.debug(cmd)
-    result = conn.run(cmd, warn=warn)
+    result = conn.local(cmd, warn=warn)
     return result
 
 
@@ -164,11 +116,22 @@ class PortForward:
 
 
 def new_tester_ssh_connection(setup_test_container):
+    config_hide = Config()
+    config_hide.run.hide = True
     with Connection(
         host="localhost",
         user=setup_test_container.user,
         port=setup_test_container.port,
-        connect_timeout=60,
+        config=config_hide,
+        connect_kwargs={
+            "key_filename": setup_test_container.key_filename,
+            "password": "",
+            "timeout": 60,
+            "banner_timeout": 60,
+            "auth_timeout": 60,
+            "allow_agent": False,
+            "look_for_keys": False,
+        },
     ) as conn:
 
         ready = _probe_ssh_connection(conn)
@@ -204,7 +167,8 @@ def _probe_ssh_connection(conn):
             result = conn.run("true", hide=True)
             if result.exited == 0:
                 ready = True
-        except ConnectionError as e:
+
+        except SSHException as e:
             if not (
                 str(e).endswith("Connection reset by peer")
                 or str(e).endswith("Error reading SSH protocol banner")


### PR DESCRIPTION
This is a temporary revert in order to unblock the updates for 3rd party repositories.

It will be re-applied once all repositories are ready to migrate away from Fabric.

This reverts commit e0910f6c7b15274402c40fba6844ca32dae72116.