### PR TITLE
QA-691: Upgrade Raspberry Pi OS tester image for Bullseye release

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 image: docker:git
 
 variables:
-  RASPBIAN_VERSION: '2019-07-10'
+  RASPIOS_VERSION: '2023-05-03'
   DOCKER_REPOSITORY: 'mendersoftware/mender-test-containers'
   DOCKER_HUB_USERNAME: 'menderbuildsystem'
   DOCKER_BUILDKIT: 1
@@ -34,7 +34,7 @@ stages:
   - test
   - publish
 
-build:prepare:raspbian:
+build:prepare:raspios:
   tags:
     - mender-qa-worker-generic-light
   stage: build
@@ -42,25 +42,25 @@ build:prepare:raspbian:
   image: buildpack-deps:scm
   script:
     - cd docker/docker-files-raspbian
-    - apt-get update && apt-get install -yyq sudo unzip fdisk
-    - ./prepare-raspbian-img.sh ${RASPBIAN_VERSION}
+    - apt-get update && apt-get install -yyq sudo unzip xz-utils fdisk
+    - ./prepare-raspbian-img.sh ${RASPIOS_VERSION}
     - cd .. && tar -cvf $CI_PROJECT_DIR/docker-files-raspbian.tar docker-files-raspbian
   artifacts:
     expire_in: 2w
     paths:
       - docker-files-raspbian.tar
 
-build:raspbian_latest:
+build:raspios:
   tags:
     - mender-qa-worker-generic-light
   stage: build
   needs:
-    - job: build:prepare:raspbian
+    - job: build:prepare:raspios
       artifacts: true
   services:
     - docker:dind
   variables:
-    CONTAINER_TAG: "rasbian_latest"
+    CONTAINER_TAG: "raspios-bullseye"
   script:
     - echo "INFO - Building and Pushing ${CONTAINER_TAG}-${CI_PIPELINE_ID} to the registry ${CI_REGISTRY_IMAGE}"
     - echo $CI_REGISTRY_PASSWORD | docker login -u $CI_REGISTRY_USER $CI_REGISTRY --password-stdin
@@ -68,7 +68,7 @@ build:raspbian_latest:
     - docker build
         --cache-from ${CI_REGISTRY_IMAGE}:${CONTAINER_TAG}-master
         -t ${CI_REGISTRY_IMAGE}:${CONTAINER_TAG}-${CI_PIPELINE_ID}
-        --build-arg raspbian_version=${RASPBIAN_VERSION}
+        --build-arg raspios_version=${RASPIOS_VERSION}
         --push
         docker-files-raspbian
     # Upload to artifact storage left for backwards compatibility
@@ -94,7 +94,7 @@ build:acceptance-testing:
         --cache-from ${CI_REGISTRY_IMAGE}:${CONTAINER_TAG}-master
         -f backend-acceptance-testing/Dockerfile.backend-tests
         -t ${CI_REGISTRY_IMAGE}:${CONTAINER_TAG}-${CI_PIPELINE_ID}
-        --build-arg raspbian_version=${RASPBIAN_VERSION}
+        --build-arg raspbian_version=${RASPIOS_VERSION}
         --push
         backend-acceptance-testing
     # Upload to artifact storage left for backwards compatibility
@@ -315,13 +315,13 @@ build:mongodb-backup-runner:
     - echo -n $DOCKER_HUB_PASSWORD | docker login -u $DOCKER_HUB_USERNAME --password-stdin
     - echo $CI_REGISTRY_PASSWORD | docker login -u $CI_REGISTRY_USER $CI_REGISTRY --password-stdin
 
-publish:raspbian_latest:
+publish:raspios-bullseye:
   extends: .template:publish
   needs:
-    - job: build:raspbian_latest
+    - job: build:raspios
       artifacts: true
   variables:
-    CONTAINER_TAG: "rasbian_latest"
+    CONTAINER_TAG: "raspios-bullseye"
   script:
     # backward compatibility: pushing to the Docker Hub
     - echo "publishing image to Docker Hub"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -71,7 +71,7 @@ build:raspbian_latest:
         --build-arg raspbian_version=${RASPBIAN_VERSION}
         --push
         docker-files-raspbian
-    # Upload to artifact storage left for backwards compatiblity
+    # Upload to artifact storage left for backwards compatibility
     - docker save ${CI_REGISTRY_IMAGE}:${CONTAINER_TAG}-${CI_PIPELINE_ID} > raspbianImage.tar
   artifacts:
     expire_in: 2w
@@ -97,7 +97,7 @@ build:acceptance-testing:
         --build-arg raspbian_version=${RASPBIAN_VERSION}
         --push
         backend-acceptance-testing
-    # Upload to artifact storage left for backwards compatiblity
+    # Upload to artifact storage left for backwards compatibility
     - docker save ${CI_REGISTRY_IMAGE}:${CONTAINER_TAG}-${CI_PIPELINE_ID} > acceptanceTestingImage.tar
   artifacts:
     expire_in: 2w
@@ -126,7 +126,7 @@ build:gui-e2e-testing:
         --push
         gui-e2e-testing
     - docker save ${CI_REGISTRY_IMAGE}:${CONTAINER_TAG}-${CI_PIPELINE_ID} > guiE2eTestingImage.tar
-    # Upload to temporary S3 bucket left for backwards compatiblity
+    # Upload to temporary S3 bucket left for backwards compatibility
     - mender_ci_save_tmp_artifact guiE2eTestingImage.tar
   artifacts:
     paths:
@@ -150,7 +150,7 @@ build:backend-integration-testing:
         -f backend-integration-testing/Dockerfile
         --push
         backend-integration-testing
-    # Upload to artifact storage left for backwards compatiblity
+    # Upload to artifact storage left for backwards compatibility
     - docker save ${CI_REGISTRY_IMAGE}:${CONTAINER_TAG}-${CI_PIPELINE_ID} > integrationTestingImage.tar
   artifacts:
     expire_in: 2w

--- a/conftest.py
+++ b/conftest.py
@@ -93,7 +93,7 @@ def setup_mender_configured(
 
     url = "https://downloads.mender.io/repos/debian/pool/main/m/mender-client/"
     for pkg in pkgs_to_install:
-        pkg_url = url + f"{pkg}_{mender_deb_version}-1%2bdebian%2bbuster_armhf.deb"
+        pkg_url = url + f"{pkg}_{mender_deb_version}-1%2Bdebian%2Bbullseye_armhf.deb"
         filename = urllib.parse.unquote(os.path.basename(pkg_url))
         # Install deb package and missing dependencies
         setup_tester_ssh_connection.run(f"wget {pkg_url}")

--- a/container_props.py
+++ b/container_props.py
@@ -49,7 +49,7 @@ class ContainerProps:
 
 
 MenderTestRaspbian = ContainerProps(
-    image_name="registry.gitlab.com/northern.tech/mender/mender-test-containers:rasbian_latest-master",
+    image_name="registry.gitlab.com/northern.tech/mender/mender-test-containers:raspios-bullseye-master",
     device_type="raspberrypi3",
     key_filename=os.path.join(
         os.path.dirname(os.path.realpath(__file__)), "docker/ssh-keys/key"

--- a/docker/docker-files-raspbian/Dockerfile
+++ b/docker/docker-files-raspbian/Dockerfile
@@ -1,26 +1,28 @@
 FROM alpine:3.19.1
 
-# Docker image to emulate Raspbian stock image with QEMU. See tutorial at:
-# https://github.com/wimvanderbauwhede/limited-systems/wiki/Raspbian-%22stretch%22-for-Raspberry-Pi-3-on-QEMU
+# Docker image to emulate Rasperry Pi OS bullseye image with QEMU. See:
+# https://github.com/dhruvvyas90/qemu-rpi-kernel/
 
 EXPOSE 8822
 
-ARG raspbian_version
-RUN test -n "${raspbian_version}" || (echo "Argument 'raspbian_version' is mandatory." && exit 1)
-ENV version=${raspbian_version}
+ARG raspios_version
+RUN test -n "${raspios_version}" || (echo "Argument 'raspios_version' is mandatory." && exit 1)
+ENV version=${raspios_version}
 
 RUN mkdir /testing
 
 RUN apk add --no-cache qemu-system-arm
 
-COPY ${version}-raspbian-mender-testing.img /testing/
-COPY kernel-qemu-4.19.50-buster /testing/
-COPY versatile-pb-buster.dtb /testing/
+COPY ${version}-raspios-bullseye-armhf-lite-mender-testing.img /testing/
 
-ENTRYPOINT /usr/bin/qemu-system-arm -kernel /testing/kernel-qemu-4.19.50-buster \
-           -dtb /testing/versatile-pb-buster.dtb -m 256 -M versatilepb \
+RUN wget -q -nc -P /testing \
+    https://github.com/dhruvvyas90/qemu-rpi-kernel/raw/master/kernel-qemu-5.10.63-bullseye \
+    https://github.com/dhruvvyas90/qemu-rpi-kernel/raw/master/versatile-pb-bullseye-5.10.63.dtb
+
+ENTRYPOINT /usr/bin/qemu-system-arm -kernel /testing/kernel-qemu-5.10.63-bullseye \
+           -dtb /testing/versatile-pb-bullseye-5.10.63.dtb -m 256 -M versatilepb \
            -cpu arm1176 -nographic -append \
            "rw console=ttyAMA0 root=/dev/sda2 rootfstype=ext4 loglevel=8 rootwait fsck.repair=yes memtest=1" \
-           -drive file=/testing/${version}-raspbian-mender-testing.img,format=raw \
+           -drive file=/testing/${version}-raspios-bullseye-armhf-lite-mender-testing.img,format=raw \
            -device virtio-net-pci,netdev=unet \
            -netdev user,id=unet,hostfwd=tcp::8822-:22

--- a/docker/docker-files-raspbian/prepare-raspbian-img.sh
+++ b/docker/docker-files-raspbian/prepare-raspbian-img.sh
@@ -1,16 +1,15 @@
 #!/bin/sh
 
-# Downloads Raspbian SD image and prepares it for testing (enable SSH and add trusted key)
-# Downloads also the dependencies (kernel and dtb file) for QEMU emulation
+# Downloads Raspberry Pi OS image and prepares it for testing (create user, enable SSH and add trusted key)
 
 set -e -x
 
 show_help_and_exit() {
   cat << EOF
-Usage: $0 raspbian-version
+Usage: $0 raspios-version
 
 Arguments:
-    raspbian-version    - Official Raspbian Buster version, for example 2019-07-10
+    raspios-version    - Official Raspberry Pi OS Bullseye version, for example 2023-05-03
 EOF
   exit 1
 }
@@ -38,64 +37,64 @@ scriptdir=$(cd `dirname $0` && pwd)
 workdir=${currdir}/tmp-work
 mkdir -p ${workdir}
 
-raspbian_filename_zip="${version}-raspbian-buster-lite.zip"
-raspbian_filename_img="${version}-raspbian-buster-lite.img"
-raspbian_mender_filename_img="${version}-raspbian-mender-testing.img"
+raspios_filename_xz="${version}-raspios-bullseye-armhf-lite.img.xz"
+raspios_filename_img="${raspios_filename_xz%.xz}"
+raspios_mender_filename_img="${raspios_filename_img%.img}-mender-testing.img"
 
-if [ -f ${currdir}/${raspbian_mender_filename_img} ]; then
+if [ -f ${currdir}/${raspios_mender_filename_img} ]; then
     echo "Found testing image in current directory. Exiting"
     exit 0
 fi
 
-# Get superuser privilages to be able to mount the SD image
+# Get superuser privileges to be able to mount the SD image
 sudo true
 
 cd ${workdir}
 
-# For some reason, Raspbian version 2019-04-08 is in a folder named 2019-04-09
-if [ ${version} = "2019-04-08" ]; then
-    raspbian_url="https://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2019-04-09/${raspbian_filename_zip}"
-# For some reason, Raspbian version 2019-07-10 is in a folder named 2019-07-12
-elif [ ${version} = "2019-07-10" ]; then
-    raspbian_url="https://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2019-07-12/${raspbian_filename_zip}"
-else
-    raspbian_url="https://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-${version}/${raspbian_filename_zip}"
-fi
+raspios_url="https://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-${version}/${version}-raspios-bullseye-armhf-lite.img.xz"
 
-echo "##### Donwloading and extracting..."
-wget -q -nc ${raspbian_url}
-unzip ${raspbian_filename_zip}
-rm ${raspbian_filename_zip}
-wget -q -nc https://raw.githubusercontent.com/dhruvvyas90/qemu-rpi-kernel/master/kernel-qemu-4.19.50-buster
-wget -q -nc https://raw.githubusercontent.com/dhruvvyas90/qemu-rpi-kernel/master/versatile-pb-buster.dtb
+echo "##### Downloading and extracting..."
+wget -q -nc ${raspios_url}
+unxz ${raspios_filename_xz}
 
 echo "##### Preparing image for tests..."
-boot_start=$(fdisk -l ${raspbian_filename_img} | grep Linux | tr -s ' ' | cut -d ' ' -f2)
-sector_size=$(fdisk -l ${raspbian_filename_img} | grep '^Sector' | cut -d' ' -f4)
-offset=$(expr $boot_start \* $sector_size)
-mkdir -p img-rootfs
-sudo mount -o loop,offset=$offset ${raspbian_filename_img} img-rootfs
+sector_size=$(fdisk -l ${raspios_filename_img} | grep '^Sector' | cut -d' ' -f4)
+boot_start=$(fdisk -l ${raspios_filename_img} | grep W95 | tr -s ' ' | cut -d ' ' -f2)
+boot_offset=$(expr $boot_start \* $sector_size)
+rootfs_start=$(fdisk -l ${raspios_filename_img} | grep Linux | tr -s ' ' | cut -d ' ' -f2)
+rootfs_offset=$(expr $rootfs_start \* $sector_size)
 
+# Tweaks for the boot partition
+mkdir -p img-boot
+sudo mount -o loop,offset=$boot_offset ${raspios_filename_img} img-boot
+
+sudo touch img-boot/ssh
+sudo tee img-boot/userconf.txt > /dev/null << EOF
+pi:$(openssl passwd "securepassword")
+EOF
+
+sleep 1
+sudo umount img-boot
+rmdir img-boot
+
+# Tweaks for the rootfs
+mkdir -p img-rootfs
+sudo mount -o loop,offset=$rootfs_offset ${raspios_filename_img} img-rootfs
+
+# Raspberry Pi OS comes with this oneshot service to generate SSH keys that requires /dev/hwrng, which although
+# existing it is unusable in QEMU. See the sources:
+# https://github.com/RPi-Distro/raspberrypi-sys-mods/blob/bullseye/debian/raspberrypi-sys-mods.regenerate_ssh_host_keys.service
+# https://github.com/RPi-Distro/raspberrypi-sys-mods/blob/bullseye/usr/lib/raspberrypi-sys-mods/regenerate_ssh_host_keys
+sudo sed -i 's|dd|true #dd|' img-rootfs/usr/lib/raspberrypi-sys-mods/regenerate_ssh_host_keys
 sudo mkdir img-rootfs/home/pi/.ssh
 cat ${scriptdir}/../ssh-keys/key.pub | sudo tee img-rootfs/home/pi/.ssh/authorized_keys
-sudo ln -s /lib/systemd/system/ssh.service img-rootfs/etc/systemd/system/multi-user.target.wants/ssh.service
 
-# Allow APT Suite change in the release info
-#
-# Upstream repository http://raspbian.raspberrypi.org/raspbian has changed buster
-# release suite from "stable" to "oldstable". The following configuration option
-# allows APT to update without user interaction.
-# This is the default un newer versions of apt, see:
-#   https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=931566
-#
-echo 'Acquire::AllowReleaseInfoChange::Suite "true";' | sudo tee img-rootfs/etc/apt/apt.conf.d/99release-change-suite
-
+sleep 1
 sudo umount img-rootfs
 rmdir img-rootfs
 
-mv ${raspbian_filename_img} ${currdir}/${raspbian_mender_filename_img}
-mv kernel-qemu-4.19.50-buster ${currdir}/
-mv versatile-pb-buster.dtb ${currdir}/
+echo "##### Copying modified image..."
+mv ${raspios_filename_img} ${currdir}/${raspios_mender_filename_img}
 
 cd ${currdir}
 rm -rf ${workdir}

--- a/helpers.py
+++ b/helpers.py
@@ -151,8 +151,11 @@ def wait_for_container_boot(docker_container_id):
         )
 
         # Check on the last few chars only, so that we can detect reboots
+        # For Raspberry Pi OS, the tty prompt comes earlier than the SSH server, so wait for the later
         if re.search(
-            "(Poky|GNU/Linux).* tty", output.decode("utf-8")[-1000:], flags=re.MULTILINE
+            "(Poky.* tty|Started.*OpenBSD Secure Shell server)",
+            output.decode("utf-8")[-1000:],
+            flags=re.MULTILINE,
         ):
             ready = True
 


### PR DESCRIPTION
    In the context of deprecating Debian Buster, we need to bump the tester
    image to the oldest still supported release.
    
    At the time of Bullseye release, the upstream project renamed the OS
    from "Raspbian" to "Raspberry Pi OS" (`raspios` for short) so let's stick
    to that for our naming of the image and the internal variables. For the
    Docker image name, remove the "latest" part as it is not meaningful.
    
    The rest of the changes [I hope that] are self-explanatory.