### PR TITLE
ci: revert to gcp runner

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,7 +36,7 @@ stages:
 
 build:prepare:raspios:
   tags:
-    - hetzner-amd-beefy
+    - mender-qa-worker-generic-light
   stage: build
   needs: []
   image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/buildpack-deps:scm


### PR DESCRIPTION
Because of this error:
mount: img-boot: mount failed: Operation not permitted.

Ticket: None
Changelog: None