### PR TITLE
ci: Switch client acceptance tests image to Python based

### DIFF
--- a/mender-client-acceptance-testing/Dockerfile
+++ b/mender-client-acceptance-testing/Dockerfile
@@ -1,40 +1,44 @@
-FROM ubuntu:22.04
+FROM python:3.12
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 # prepare NFS cache for yocto
 RUN mkdir -p /mnt/sstate-cache
 
-# install pyyaml via pip to workardound a later conflict if installed via OS package (awscli depends on python3-yaml)
-RUN apt-get update -qq && apt-get install -yyq python3-pip && pip3 install --upgrade pip && pip3 install pyyaml
-
-# Get OS requirements from master
+# OS requirements from master
 # linux-modules-$(uname -r | sed 's/gcp/gke/') is a workaround for https://northerntech.atlassian.net/browse/QA-597
-RUN apt-get install -yyq wget && \
+RUN apt-get update -qq && apt-get install -yyq wget && \
     wget https://raw.githubusercontent.com/mendersoftware/meta-mender/master/tests/acceptance/requirements_deb.txt && \
-    apt-get install -yyq $(cat requirements_deb.txt) && apt-get install -yq linux-modules-$(uname -r | sed 's/gcp/gke/') && \
-    apt-get remove -yyq docker docker.io containerd runc && apt-get install -yyq ca-certificates curl gnupg lsb-release && \
-    mkdir -p /etc/apt/keyrings && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null && \
-    apt-get update -qq && apt-get install -yyq docker-ce docker-ce-cli containerd.io docker-compose-plugin
+    apt-get install -yyq $(cat requirements_deb.txt) && apt-get install -yq linux-modules-$(uname -r | sed 's/gcp/gke/')
+
+# Install Docker Engine as per official instructions. See https://docs.docker.com/engine/install/debian/
+RUN for pkg in docker.io docker-doc docker-compose podman-docker containerd runc; do apt-get remove -yyq $pkg; done && \
+    apt-get update -qq && \
+    apt-get install -yyq ca-certificates curl  && \
+    install -m 0755 -d /etc/apt/keyrings  && \
+    curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc  && \
+    chmod a+r /etc/apt/keyrings/docker.asc  && \
+    echo \
+            "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian \
+            $(. /etc/os-release && echo "$VERSION_CODENAME") stable" > /etc/apt/sources.list.d/docker.list && \
+    apt-get update -qq && \
+    apt-get install -yyq docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+# Python 3 requirements from master
+RUN wget https://raw.githubusercontent.com/mendersoftware/meta-mender/master/tests/acceptance/requirements_py3.txt && \
+    pip install -r requirements_py3.txt && \
+    rm requirements_py3.txt
 
 # Locales
 RUN locale-gen --purge en_US.UTF-8
 ENV LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 LANGUAGE=en_US.UTF-8
 
-# Python 3 requirements from master
-RUN wget https://raw.githubusercontent.com/mendersoftware/meta-mender/master/tests/acceptance/requirements_py3.txt && \
-    pip3 install -r requirements_py3.txt && \
-    rm requirements_py3.txt
-
-# mender user dir
+# mender user
 RUN useradd -m -u 1010 mender && usermod -a -G kvm mender && usermod -a -G docker mender
-
-# Prepare mender user
 RUN mkdir -p /home/mender/.ssh && echo "mender ALL=(ALL:ALL) NOPASSWD:ALL" >> /etc/sudoers && sed -i -e 's/^\( *Defaults *requiretty *\)$/# \1/' /etc/sudoers && chown -R mender:mender /home/mender
 
 # debugfs
-RUN cp /sbin/debugfs /usr/bin/ || echo "debugfs not in /sbin/"
+RUN cp /sbin/debugfs /usr/bin/
 
 # enable sysstat monitoring suite for Debian/Ubuntu
 RUN sed -i 's/false/true/g' /etc/default/sysstat

--- a/mender-client-acceptance-testing/Dockerfile
+++ b/mender-client-acceptance-testing/Dockerfile
@@ -5,6 +5,9 @@ ENV DEBIAN_FRONTEND=noninteractive
 # prepare NFS cache for yocto
 RUN mkdir -p /mnt/sstate-cache
 
+RUN uname -r
+RUN apt-get update -qq && apt-cache search linux-modules
+
 # OS requirements from master
 # linux-modules-$(uname -r | sed 's/gcp/gke/') is a workaround for https://northerntech.atlassian.net/browse/QA-597
 RUN apt-get update -qq && apt-get install -yyq wget && \


### PR DESCRIPTION
Which is a Debian based image with Python installed from source in `/usr/local` (which does not conflict with system's Python).

This aims to address two issues:

* Latest Ubuntu and Debian images follow PEP 668 marking the Python environment as "externally managed" and preventing pip to install modules and apps normally. It can be ignored (not recommended) or workarrounded with virtual environments (the proper way, although cumbersome for containers)

* Ubuntu is moving more and more towards snaps, so we will be forced to mix deb packages and snaps sooner or later, which doesn't make much sense for containers.

As a bonus, we get this image presumably updated on newer Debian releases and through dependabot we will catch when our own packages (namely mender-artifact) need to be updated for the new distro.