### PR TITLE
MEN-7731: Add mender-dist-packages builder image for Debian armhf

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,10 +9,16 @@ variables:
 .mender-dist-packages-image-matrix:
   parallel:
     matrix:
-      - DISTRO: debian
+      - BUILD: simulated
+        DISTRO: raspberrypios
+        RELEASE: [bullseye, bookworm]
+        ARCH: [armhf]
+      - BUILD: crosscompile
+        DISTRO: debian
         RELEASE: [bullseye, bookworm]
         ARCH: [amd64, armhf, arm64]
-      - DISTRO: ubuntu
+      - BUILD: crosscompile
+        DISTRO: ubuntu
         RELEASE: [focal, jammy, noble]
         ARCH: [amd64, armhf, arm64]
 
@@ -186,7 +192,7 @@ build:aws-k8s-pipeline-toolbox:
     - *dind-login
   script:
     - apk add bash
-    - CONTAINER_TAG=mender-dist-packages-builder-${DISTRO}-${RELEASE}-${ARCH}
+    - CONTAINER_TAG=mender-dist-packages-builder-${BUILD}-${DISTRO}-${RELEASE}-${ARCH}
     - echo "INFO - Building and Pushing ${CONTAINER_TAG}-${CI_PIPELINE_ID} to the registry ${CI_REGISTRY_IMAGE}"
     - echo $CI_REGISTRY_PASSWORD | docker login -u $CI_REGISTRY_USER $CI_REGISTRY --password-stdin
     - cd mender-dist-packages-building
@@ -422,16 +428,16 @@ publish:mender-dist-packages-image:
   extends: .template:publish
   dependencies:
     # NOTE: We should depend on each of the jobs individually with:
-    # - "build:mender-dist-packages-image: [${DISTRO}, ${RELEASE}, ${ARCH}]"
+    # - "build:mender-dist-packages-image: [${BUILD}, ${DISTRO}, ${RELEASE}, ${ARCH}]"
     # However GitLab does not seem to expand these variables on a dependencies
     # key. Use arbitrary one of them and assume that they all passed (using
     # depends instead of needs ensures that the whole previous build stage
     # needs to pass, so it should be safe).
-    - "build:mender-dist-packages-image: [debian, bullseye, amd64]"
+    - "build:mender-dist-packages-image: [crosscompile, debian, bullseye, amd64]"
   rules:
     - if: $CI_COMMIT_BRANCH == "master"
   script:
-    - CONTAINER_TAG=mender-dist-packages-builder-${DISTRO}-${RELEASE}-${ARCH}
+    - CONTAINER_TAG=mender-dist-packages-builder-${BUILD}-${DISTRO}-${RELEASE}-${ARCH}
     - *tag_n_push_to_gitlab_registry
   parallel: !reference [.mender-dist-packages-image-matrix, parallel]
 

--- a/mender-dist-packages-building/Dockerfile
+++ b/mender-dist-packages-building/Dockerfile
@@ -1,5 +1,5 @@
 ARG DISTRO=debian
-ARG RELEASE=buster
+ARG RELEASE=bookworm
 FROM $DISTRO:$RELEASE
 
 COPY requirements.txt .
@@ -9,7 +9,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
 
 ARG ARCH=amd64
 ARG DISTRO=debian
-ARG RELEASE=buster
+ARG RELEASE=bookworm
 
 RUN if [ "${DISTRO}" = "ubuntu" -a "${ARCH}" != "amd64" ]; then \
         # Unlike Debian, Ubuntu has separate repositories for the Primary Architectures (amd64, i386)

--- a/mender-dist-packages-building/Dockerfile
+++ b/mender-dist-packages-building/Dockerfile
@@ -36,23 +36,20 @@ RUN if [ "${DISTRO}" = "ubuntu" -a "${ARCH}" != "amd64" ]; then \
 RUN dpkg --add-architecture ${ARCH} && \
     apt-get update
 
-RUN if ! [ "${DISTRO}" = "debian" -a "${ARCH}" = "armhf" ]; then \
-        apt-get install -y \
-        pkg-config \
-        liblzma-dev:${ARCH} \
-        libssl-dev:${ARCH} \
-        libglib2.0-dev:${ARCH} \
-        libmount-dev:${ARCH} \
-        libc-dev:${ARCH} \
-        libc6-dev:${ARCH} \
-        linux-libc-dev:${ARCH} \
-        ; \
-    fi
+RUN apt-get install -y \
+    pkg-config \
+    liblzma-dev:${ARCH} \
+    libssl-dev:${ARCH} \
+    libglib2.0-dev:${ARCH} \
+    libmount-dev:${ARCH} \
+    libc-dev:${ARCH} \
+    libc6-dev:${ARCH} \
+    linux-libc-dev:${ARCH}
 
 RUN if [ "${ARCH}" = "arm64" ]; then \
         apt-get install -y gcc-aarch64-linux-gnu; \
     fi
 
-RUN if [ "${ARCH}" = "armhf" -a "${DISTRO}" != "debian" ]; then \
+RUN if [ "${ARCH}" = "armhf" ]; then \
         apt-get install -y gcc-arm-linux-gnueabihf; \
     fi

--- a/mender-dist-packages-building/build.sh
+++ b/mender-dist-packages-building/build.sh
@@ -43,7 +43,7 @@ if [ $required_arguments == false ]; then
     exit 1
 fi
 
-if [ "$ARCH" = "armhf" -a "$DISTRO" = "debian" ]; then
+if [ "$DISTRO" = "raspberrypios" -a "$ARCH" = "armhf" ]; then
     # Move requirements.txt to be in correct build context
     cp requirements.txt armhf/
 
@@ -72,7 +72,8 @@ if [ "$ARCH" = "armhf" -a "$DISTRO" = "debian" ]; then
         --file armhf/Dockerfile.rpi \
         --push \
         armhf
-else
+
+elif [ "$DISTRO" = "debian" -o "$DISTRO" = "ubuntu" ]; then
     docker build \
         --cache-from ${CONTAINER_TAG}-master \
         --tag ${CONTAINER_TAG}-${CI_PIPELINE_ID} \
@@ -81,4 +82,8 @@ else
         --build-arg ARCH \
         --push \
         .
+
+else
+    echo "Combination of DISTRO '$DISTRO' and ARCH '$ARCH' is not supported"
+    exit 1
 fi


### PR DESCRIPTION
Important: this commit modifies the name of the builder images.
    
The purpose is to better show what the image is meant to (simulated build or cross compiling build) and, most importantly, not reuse the old Debian armhf (what was really Raspberry Pi OS armhf) with the new Debian armhf (the "good" one).

The actual changes are minimal: remove the special handling of the Dockerfile for Debian armhf and add some extra checks in the wrapper to make sure we don't build unexpected images.
