### PR TITLE
QA-929: Increase timeout waiting for container to 15 minutes

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -203,7 +203,7 @@ def new_tester_ssh_connection(setup_test_container):
 def wait_for_container_boot(docker_container_id):
     assert docker_container_id is not None
     ready = False
-    timeout = time.time() + 60 * 3
+    timeout = time.time() + 60 * 15
     while not ready and time.time() < timeout:
         time.sleep(5)
         output = subprocess.check_output(


### PR DESCRIPTION
We started to see random failures in mender-dist-packages acceptance tests on this wait for boot. This test suite run arm containers on x86 through emulation.

While in the past 3 minutes showed to be enough, it seems like some either in the image or in the infra made the tests run into this limit.