### PR TITLE
Fixes for running tests locally and on a different architecture than armhf

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -30,6 +30,14 @@ def do_setup_test_container(request, setup_test_container_props, mender_version)
     # This should be parametrized in the mother project.
     image = setup_test_container_props.image_name
 
+    if image == LOCAL_RUN_NO_CONTAINER:
+        if setup_test_container_props.append_mender_version:
+            raise ValueError("Not starting a container, no Mender version specificity")
+
+        # No container to start, just return the properties for use in other
+        # places/fixtures.
+        return setup_test_container_props
+
     if setup_test_container_props.append_mender_version:
         image = "%s:%s" % (image, mender_version)
 

--- a/conftest.py
+++ b/conftest.py
@@ -129,14 +129,9 @@ def setup_mender_configured(
         filename = urllib.parse.unquote(os.path.basename(pkg_url))
         # Install deb package and missing dependencies
         setup_tester_ssh_connection.run(f"wget {pkg_url}")
-        result = setup_tester_ssh_connection.sudo(
-            f"DEBIAN_FRONTEND=noninteractive dpkg --install {filename}", warn=True
+        setup_tester_ssh_connection.sudo(
+            f"DEBIAN_FRONTEND=noninteractive apt -y install ./{filename}"
         )
-        if result.exited != 0:
-            setup_tester_ssh_connection.sudo("apt-get update")
-            setup_tester_ssh_connection.sudo(
-                "apt-get --fix-broken --assume-yes install"
-            )
 
     # Verify that the packages were installed
     for pkg in pkgs_to_install:

--- a/container_props.py
+++ b/container_props.py
@@ -15,6 +15,8 @@
 
 import os
 
+from .helpers import LOCAL_RUN_NO_CONTAINER
+
 
 class ContainerProps:
     image_name = None
@@ -63,3 +65,4 @@ MenderTestQemux86_64 = ContainerProps(
         os.path.dirname(os.path.realpath(__file__)), "docker/ssh-keys/key"
     ),
 )
+MenderTestNoContainer = ContainerProps(LOCAL_RUN_NO_CONTAINER)


### PR DESCRIPTION
Developed together with https://github.com/mendersoftware/mender-dist-packages/pull/537. And proven to be working by [its pipeline](https://gitlab.com/Northern.tech/Mender/mender-dist-packages/-/pipelines/1943849242).