### PR TITLE
chore: Add a base image for Mender C++ jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -356,6 +356,7 @@ build:release-please:
     DOCKER_TLS_CERTDIR: "/certs"
     DOCKER_TLS_VERIFY: 1
     DOCKER_CERT_PATH: "$DOCKER_TLS_CERTDIR/client"
+    PLATFORMS: "linux/amd64,linux/arm64"
   services:
     - name: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/docker:${DOCKER_VERSION}-dind
       alias: docker
@@ -369,7 +370,7 @@ build:release-please:
     - echo "INFO - Building and Pushing ${CONTAINER_TAG}-${CI_PIPELINE_ID} and ${CONTAINER_TAG}-${CI_COMMIT_BRANCH} to the registry ${CI_REGISTRY_IMAGE}"
     - cd ${BASE_IMAGE_DIR}
     - docker buildx build
-        --platform linux/amd64,linux/arm64
+        --platform ${PLATFORMS}
         --cache-to type=registry,ref=${CI_REGISTRY_IMAGE}:${CONTAINER_TAG}_ci_cache,mode=max
         --cache-from type=registry,ref=${CI_REGISTRY_IMAGE}:${CONTAINER_TAG}_ci_cache
         --tag ${CI_REGISTRY_IMAGE}:${CONTAINER_TAG}-${CI_PIPELINE_ID}
@@ -413,6 +414,19 @@ build:base-alpine:
         - base-alpine/Dockerfile
     - when: manual
       allow_failure: true
+
+build:base-mender-cpp:
+  extends: .build:base-image
+  variables:
+    CONTAINER_TAG: "base-mender-cpp"
+    BASE_IMAGE_DIR: "base-mender-cpp"
+    PLATFORMS: "linux/amd64"
+  rules:
+    - if: $CI_COMMIT_BRANCH == "master"
+    - when: manual
+      allow_failure: true
+  tags:
+    - hetzner-amd-beefy
 
 build:python-black:
   extends: .build:base-image

--- a/base-mender-cpp/Dockerfile
+++ b/base-mender-cpp/Dockerfile
@@ -1,0 +1,21 @@
+FROM debian:13
+
+ARG MENDER_ARTIFACT_VERSION=4.4.0
+ENV DEBIAN_FRONTEND=non-interactive
+
+RUN apt update && \
+    apt install -yyq \
+    ccache clang cmake git g++ make pkg-config lcov \
+    liblmdb++-dev libboost-dev libboost-log-dev libssl-dev libarchive-dev libdbus-1-dev \
+    curl dbus stunnel4 tinyproxy-bin netcat-openbsd wget zstd xz-utils && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN wget "https://downloads.mender.io/repos/workstation-tools/pool/main/m/mender-artifact/mender-artifact_${MENDER_ARTIFACT_VERSION}-1%2bdebian%2btrixie_amd64.deb" \
+      --output-document mender-artifact.deb && \
+    apt-get update && \
+    apt install --assume-yes --quiet ./mender-artifact.deb && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN mender-artifact --version

--- a/renovate.json
+++ b/renovate.json
@@ -23,7 +23,7 @@
   "customManagers": [
     {
       "customType": "regex",
-      "managerFilePatterns": ["/gui-e2e-testing\/Dockerfile/"],
+      "managerFilePatterns": ["/gui-e2e-testing\/Dockerfile/", "/base-mender-cpp\/Dockerfile/"],
       "matchStrings": [
         "MENDER_ARTIFACT_VERSION=\\s*[\"']?(?<currentValue>[\\d\\.]+)[\"']?"
       ],


### PR DESCRIPTION
Jobs in the _mender_ repo need a similar environment. Let's provide them a base image instead of doing the very similar `apt-get update && apt install...` steps in all of them individually.

Ticket: none
Changelog: none