### PR TITLE
feat(github-status): add github-status image with curl and git

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -69,3 +69,9 @@ updates:
     package-ecosystem: pip
     schedule:
       interval: monthly
+  - commit-message:
+      prefix: chore
+    directory: /github-status
+    package-ecosystem: docker
+    schedule:
+      interval: monthly

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -441,6 +441,18 @@ build:python-black:
     - when: manual
       allow_failure: true
 
+build:github-status:
+  extends: .build:base-image
+  variables:
+    CONTAINER_TAG: "github-status"
+    BASE_IMAGE_DIR: "github-status"
+  rules:
+    - if: $CI_COMMIT_BRANCH == "master"
+      changes:
+        - github-status/Dockerfile
+    - when: manual
+      allow_failure: true
+
 .template:publish:
   tags:
     - hetzner-amd-beefy

--- a/github-status/Dockerfile
+++ b/github-status/Dockerfile
@@ -1,0 +1,5 @@
+FROM curlimages/curl-base:8.20.0
+
+USER root
+RUN apk add --no-cache git
+USER curl_user


### PR DESCRIPTION
- Add a new `github-status` Docker image based on `curlimages/curl-base` with `git` preinstalled
- Add `build:github-status` CI job to build and publish the image
- Required by mendertesting to resolve the PR head SHA via `git rev-parse HEAD^2` in status-posting jobs


Ticket: QA-1505