### PR TITLE
chore: Add mender-base-ubuntu container image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -457,6 +457,18 @@ build:base-mender-cpp:
   tags:
     - hetzner-amd-beefy
 
+build:mender-base-ubuntu:
+  extends: .build:base-image
+  variables:
+    CONTAINER_TAG: "mender-base-ubuntu"
+    IMAGE_NAME: "mender-base-ubuntu"
+    BASE_IMAGE_DIR: "mender-base-ubuntu"
+    PLATFORMS: "linux/amd64"
+  rules:
+    - if: $CI_COMMIT_BRANCH == "master"
+    - when: manual
+      allow_failure: true
+
 build:python-black:
   extends: .build:base-image
   variables:

--- a/mender-base-ubuntu/Dockerfile
+++ b/mender-base-ubuntu/Dockerfile
@@ -1,0 +1,18 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=non-interactive
+
+RUN apt update && \
+    apt install -yyq \
+    curl jq python3-pip && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://downloads.mender.io/repos/debian/gpg | tee /etc/apt/trusted.gpg.d/mender.asc && \
+    echo "deb [arch=$(dpkg --print-architecture)] https://downloads.mender.io/repos/workstation-tools ubuntu/noble/stable main" | tee /etc/apt/sources.list.d/mender.list && \
+    apt update && \
+    apt install --assume-yes --quiet mender-artifact && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN mender-artifact --version


### PR DESCRIPTION
A Ubuntu base image with mender-artifact pre-installed and the workstation tools repository enabled.

Ticket: none
Changelog: none