### PR TITLE
ci: remove Docker Hub publishing for gui-e2e-testing and mender-client-acceptance-testing

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,8 +1,6 @@
 image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/docker:git
 
 variables:
-  DOCKER_REPOSITORY: 'mendersoftware/mender-test-containers'
-  DOCKER_HUB_USERNAME: 'menderbuildsystem'
   DOCKER_BUILDKIT: 1
   DOCKER_VERSION: "27.3"
 
@@ -494,7 +492,6 @@ build:python-black:
     - if: $CI_COMMIT_BRANCH == "master"
   before_script:
     - *requires-docker
-    - echo -n $DOCKER_HUB_PASSWORD | docker login -u $DOCKER_HUB_USERNAME --password-stdin
     - echo $CI_REGISTRY_PASSWORD | docker login -u $CI_REGISTRY_USER $CI_REGISTRY --password-stdin
 
 publish:gui-e2e-testing:
@@ -507,16 +504,6 @@ publish:gui-e2e-testing:
     IMAGE_NAME: "gui-e2e-testing"
     IMAGE_TAG: "${CI_COMMIT_BRANCH}"
   script:
-    # backward compatibility: pushing to the Docker Hub
-    - apk add --no-cache aws-cli curl
-    - eval "$(curl https://raw.githubusercontent.com/mendersoftware/mendertesting/master/mender-ci-common.sh)"
-    # Fetch from temporary S3 bucket
-    - mender_ci_load_tmp_artifact guiE2eTestingImage.tar
-    - echo "publishing image to Docker Hub"
-    - docker load -i guiE2eTestingImage.tar
-    - docker tag ${CI_REGISTRY_IMAGE}:${CONTAINER_TAG}-${CI_PIPELINE_ID} $DOCKER_REPOSITORY:$CONTAINER_TAG
-    - docker push $DOCKER_REPOSITORY:$CONTAINER_TAG
-    # Gitlab registry
     - *tag_n_push_to_gitlab_registry
 
 publish:mender-client-acceptance-testing:
@@ -529,16 +516,6 @@ publish:mender-client-acceptance-testing:
     IMAGE_NAME: "mender-client-acceptance-testing"
     IMAGE_TAG: "${CI_COMMIT_BRANCH}"
   script:
-    # backward compatibility: pushing to the Docker Hub
-    - apk add --no-cache aws-cli curl
-    - eval "$(curl https://raw.githubusercontent.com/mendersoftware/mendertesting/master/mender-ci-common.sh)"
-    # Fetch from temporary S3 bucket
-    - mender_ci_load_tmp_artifact qaTestingImage.tar
-    - echo "publishing image to Docker Hub"
-    - docker load -i qaTestingImage.tar
-    - docker tag ${CI_REGISTRY_IMAGE}:${CONTAINER_TAG}-${CI_PIPELINE_ID} $DOCKER_REPOSITORY:$CONTAINER_TAG
-    - docker push $DOCKER_REPOSITORY:$CONTAINER_TAG
-    # Gitlab registry
     - *tag_n_push_to_gitlab_registry
 
 publish:aws-k8s-pipeline-toolbox:


### PR DESCRIPTION
Removes the backward-compatibility Docker Hub push for the `gui-e2e-testing` and `mender-client-acceptance-testing` images now that all downstream consumers have migrated to the GitLab registry. Also removes the now-unused `DOCKER_REPOSITORY`, `DOCKER_HUB_USERNAME` variables and Docker Hub login from the publish template.

Ticket: QA-1604, QA-1605