### PR TITLE
chore: Extend base-mender-cpp with libc++

### DIFF
--- a/base-mender-cpp/Dockerfile
+++ b/base-mender-cpp/Dockerfile
@@ -6,7 +6,7 @@ ENV DEBIAN_FRONTEND=non-interactive
 RUN apt update && \
     apt install -yyq \
     ccache clang cmake git g++ make pkg-config lcov \
-    liblmdb++-dev libboost-dev libboost-log-dev libssl-dev libarchive-dev libdbus-1-dev \
+    liblmdb++-dev libboost-dev libboost-log-dev libssl-dev libarchive-dev libdbus-1-dev libc++-dev libc++abi-dev \
     curl dbus stunnel4 tinyproxy-bin netcat-openbsd wget zstd xz-utils && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
We would like to build mender with more restrict libc++ libraries than the standard GNU ones. For that we need to update the building conrainer.

Ticket: QA-1626