### PR TITLE
Add Ubuntu 26 support and deprecate Ubuntu 22

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,7 +31,7 @@ variables:
         ARCH: [amd64, armhf, arm64]
       - BUILD: crosscompile
         DISTRO: ubuntu
-        RELEASE: [jammy, noble]
+        RELEASE: [jammy, noble, resolute]
         ARCH: [amd64, armhf, arm64]
 
 .tag_n_push_to_gitlab_registry: &tag_n_push_to_gitlab_registry

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,7 +31,7 @@ variables:
         ARCH: [amd64, armhf, arm64]
       - BUILD: crosscompile
         DISTRO: ubuntu
-        RELEASE: [jammy, noble, resolute]
+        RELEASE: [noble, resolute]
         ARCH: [amd64, armhf, arm64]
 
 .tag_n_push_to_gitlab_registry: &tag_n_push_to_gitlab_registry


### PR DESCRIPTION
This PR adds support for Ubuntu 26 and removes deprecated Ubuntu 22