### PR TITLE
ci: add base-mender-go image with baked Go test deps

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -448,6 +448,19 @@ build:python-black:
     - when: manual
       allow_failure: true
 
+build:base-mender-go:
+  extends: .build:base-image
+  variables:
+    CONTAINER_TAG: "base-mender-go"
+    IMAGE_NAME: "base-mender-go"
+    BASE_IMAGE_DIR: "base-mender-go"
+  rules:
+    - if: $CI_COMMIT_BRANCH == "master"
+      changes:
+        - base-mender-go/Dockerfile
+    - when: manual
+      allow_failure: true
+
 .template:publish:
   stage: publish
   services:

--- a/base-mender-go/Dockerfile
+++ b/base-mender-go/Dockerfile
@@ -1,0 +1,25 @@
+FROM golang:1.26
+
+LABEL REFRESHED_AT=20260615
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Common Go compile dependencies (union of deb-requirements.txt across Mender Go repos)
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        libglib2.0-dev \
+        liblzma-dev \
+        libssl-dev \
+        dbus \
+        e2tools && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# JUnit test-report formatter (pinned; Renovate-tracked)
+RUN go install github.com/jstemmer/go-junit-report@v1.0.0
+
+# Smoke check: every baked tool must be present at build time
+RUN go version && \
+    command -v go-junit-report && \
+    pkg-config --exists glib-2.0 && \
+    dpkg -s liblzma-dev libssl-dev e2tools dbus > /dev/null

--- a/renovate.json5
+++ b/renovate.json5
@@ -32,6 +32,15 @@
       "extractVersionTemplate": "^v?(?<version>.*)$",
       "versioningTemplate": "semver"
     },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/base-mender-go\/Dockerfile/"],
+      "matchStrings": [
+        "go install github\\.com/jstemmer/go-junit-report@(?<currentValue>v[\\d\\.]+)"
+      ],
+      "depNameTemplate": "jstemmer/go-junit-report",
+      "datasourceTemplate": "github-tags"
+    },
   ],
 
   "prHourlyLimit": 0


### PR DESCRIPTION
## What
Adds a new `base-mender-go` image (`FROM golang:1.26`) baking:
- the common Go compile deps (union of `deb-requirements.txt` across Mender Go repos:
  `libglib2.0-dev liblzma-dev libssl-dev dbus e2tools`)
- `go-junit-report` (the JUnit formatter installed at runtime today)

Wired into the existing `.build:base-image` template (multi-arch build+push, immutable
`:${CI_PIPELINE_ID}` tag + moving `:master`). Adds a Renovate custom manager tracking the
pinned `go-junit-report` version.

## Why
QA-1637 (epic QA-1636, pipeline robustness): so Go unit-test jobs stop running `apt`/`go install`
at runtime, where a flaky mirror can fail the pipeline.

## Verification
Built locally + smoke-checked: `go1.26.4`, `go-junit-report` on PATH, glib/libs present.

## Rollout
- Consumed via the new `golang-unittests-v3` template (mendertesting PR #491).
- `build:base-mender-go` is a manual job — trigger it on master once merged so the image is
  published before consumers switch.

Ticket: QA-1637