### PR TITLE
chore: add-python-dependencies

### DIFF
--- a/base-ubuntu/Dockerfile
+++ b/base-ubuntu/Dockerfile
@@ -18,6 +18,9 @@ RUN apt-get update && \
         gettext-base \
         ssh-client \
         unzip \
+        python3 \
+        python3-pip \
+        python3-venv \
         xz-utils && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Added python3, python3-pip and python3-venv standard test dependencies to ubuntu image.