### PR TITLE
ci: add base-mender-go-test image with baked Go test deps

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -462,6 +462,19 @@ build:mender-cli-acceptance-testing:
     - when: manual
       allow_failure: true
 
+build:base-mender-go-test:
+  extends: .build:base-image
+  variables:
+    CONTAINER_TAG: "base-mender-go-test"
+    IMAGE_NAME: "base-mender-go-test"
+    BASE_IMAGE_DIR: "base-mender-go-test"
+  rules:
+    - if: $CI_COMMIT_BRANCH == "master"
+      changes:
+        - base-mender-go-test/Dockerfile
+    - when: manual
+      allow_failure: true
+
 .template:publish:
   stage: publish
   services:

--- a/base-mender-go-test/Dockerfile
+++ b/base-mender-go-test/Dockerfile
@@ -1,0 +1,25 @@
+FROM golang:1.26
+
+LABEL REFRESHED_AT=20260702
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Common Go compile dependencies (union of deb-requirements.txt across Mender Go repos)
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        libglib2.0-dev \
+        liblzma-dev \
+        libssl-dev \
+        dbus \
+        e2tools && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Test runner that emits JUnit + coverage; actively maintained (pinned; Renovate-tracked)
+RUN go install gotest.tools/gotestsum@v1.13.0
+
+# Smoke check: every baked tool must be present at build time
+RUN go version && \
+    command -v gotestsum && \
+    pkg-config --exists glib-2.0 && \
+    dpkg -s liblzma-dev libssl-dev e2tools dbus > /dev/null

--- a/renovate.json5
+++ b/renovate.json5
@@ -18,6 +18,13 @@
       "matchManagers": ["git-submodules"],
       "enabled": false
     },
+    {
+      // Track the base-mender-go-test golang base image (docker category is paused above)
+      "matchManagers": ["dockerfile"],
+      "matchPackageNames": ["golang"],
+      "matchFileNames": ["base-mender-go-test/Dockerfile"],
+      "enabled": true
+    },
   ],
 
   "customManagers": [
@@ -31,6 +38,15 @@
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v?(?<version>.*)$",
       "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/base-mender-go-test\/Dockerfile/"],
+      "matchStrings": [
+        "go install gotest\\.tools/gotestsum@(?<currentValue>v[\\d\\.]+)"
+      ],
+      "depNameTemplate": "gotestyourself/gotestsum",
+      "datasourceTemplate": "github-tags"
     },
   ],
 


### PR DESCRIPTION
## What
New `base-mender-go` image (`FROM golang:1.26`) baking the common Go compile deps
(`libglib2.0-dev liblzma-dev libssl-dev dbus e2tools`) and `go-junit-report`. Wired into
`.build:base-image` (multi-arch build+push, immutable `:<pipeline-id>` + moving `:master`).
Adds a Renovate manager for the pinned `go-junit-report`.

## Why
QA-1637 (epic QA-1636): Go unit-test jobs stop running `apt`/`go install` at runtime.

## Verification
Built + smoke-checked locally: `go1.26.4`, `go-junit-report` present, libs present.

## Rollout
Consumed via the `golang-unittests-v3` template. `build:base-mender-go` is manual — trigger on
master after merge so the image is published before consumers switch.

Ticket: QA-1637