### PR TITLE
ci: add mender-cli-acceptance-testing image with baked uamqp

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -448,6 +448,20 @@ build:python-black:
     - when: manual
       allow_failure: true
 
+build:mender-cli-acceptance-testing:
+  extends: .build:base-image
+  variables:
+    CONTAINER_TAG: "mender-cli-acceptance-testing"
+    IMAGE_NAME: "mender-cli-acceptance-testing"
+    BASE_IMAGE_DIR: "mender-cli-acceptance-testing"
+    PLATFORMS: "linux/amd64"
+  rules:
+    - if: $CI_COMMIT_BRANCH == "master"
+      changes:
+        - mender-cli-acceptance-testing/Dockerfile
+    - when: manual
+      allow_failure: true
+
 .template:publish:
   stage: publish
   services:

--- a/mender-cli-acceptance-testing/Dockerfile
+++ b/mender-cli-acceptance-testing/Dockerfile
@@ -1,0 +1,21 @@
+# Base matches the acceptance job's current image (docker CLI + dind entrypoint)
+FROM docker:27-dind
+
+LABEL REFRESHED_AT=20260630
+
+# Acceptance test system packages (was: apk add ... in mender-cli/.gitlab-ci.yml).
+# `apk upgrade` keeps freshly-installed packages from diverging from base ones.
+RUN apk upgrade --no-cache && \
+    apk add --no-cache \
+        bash cmake curl dpkg e2fsprogs-extra g++ gcompat git iptables jq \
+        libffi-dev make openssh-client py3-pip python3-dev zstd screen \
+        openssl-dev openssl-libs-static
+
+# Pre-compile uamqp (the flakiest step: builds a C wheel from source at runtime today)
+RUN CFLAGS="-Wno-error=incompatible-pointer-types" CMAKE_POLICY_VERSION_MINIMUM=3.5 \
+        pip install uamqp --break-system-packages
+
+# Smoke check: the baked tools and the compiled uamqp must be importable at build time
+RUN docker --version && \
+    python3 -c "import uamqp; print('uamqp', uamqp.__version__)" && \
+    cmake --version && g++ --version


### PR DESCRIPTION
## What
New `mender-cli-acceptance-testing` image (`FROM docker:27-dind`, amd64-only) baking the
acceptance `apk` packages and the source-compiled `uamqp` wheel. Wired into `.build:base-image`.

## Why
QA-1637 (epic QA-1636): the runtime `pip install uamqp` (C compile) + ~20-pkg `apk add` is the
flakiest install in the Go repos. Baking it removes that failure mode.

## Verification
Built + smoke-checked locally: `uamqp 1.6.11` imported, docker/cmake/g++ present.

## Rollout
Consumed by mender-cli. `build:mender-cli-acceptance-testing` is manual — trigger on master after
merge so the image is published first.

Ticket: QA-1637