### PR TITLE
Downgrade base image in mender-client-acceptance-testing

### DIFF
--- a/mender-client-acceptance-testing/Dockerfile
+++ b/mender-client-acceptance-testing/Dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu:24.04
+# Pinned to 22.04 due to QA-1690
+FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PIP_BREAK_SYSTEM_PACKAGES=1


### PR DESCRIPTION
The bump from ubuntu 22.04 -> 24.04 caused the client acceptance tests
and more specifically `test:acceptance:vexpress_qemu:flash` to fail.

Downgrading until we've found the fix in QA-1690