### PR TITLE
ci: add awscli and xz-utils to mender-client-acceptance-testing base

### DIFF
--- a/mender-client-acceptance-testing/Dockerfile
+++ b/mender-client-acceptance-testing/Dockerfile
@@ -12,11 +12,16 @@ RUN apt-get update -qq && apt-get install -yyq python3-pip && pip3 install --ign
 # Get OS requirements from master
 RUN apt-get install -yyq wget && \
     wget https://raw.githubusercontent.com/mendersoftware/meta-mender/master/tests/acceptance/requirements_deb.txt && \
-    apt-get install -yyq $(cat requirements_deb.txt) && \
-    apt-get remove -yyq docker docker.io containerd runc && apt-get install -yyq ca-certificates curl gnupg lsb-release && \
+    apt-get install -yyq $(cat requirements_deb.txt) xz-utils && \
+    apt-get remove -yyq docker docker.io containerd runc && apt-get install -yyq ca-certificates curl gnupg lsb-release unzip && \
     mkdir -p /etc/apt/keyrings && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null && \
     apt-get update -qq && apt-get install -yyq docker-ce docker-ce-cli containerd.io docker-compose-plugin
+
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    ./aws/install && \
+    rm -rf awscliv2.zip aws
 
 # Locales
 RUN locale-gen --purge en_US.UTF-8


### PR DESCRIPTION
To be reused by mender-qa pipelines