### PR TITLE
ci: move mender-dist-packages-image from hetzner to k8s runner

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -199,7 +199,7 @@ build:aws-k8s-pipeline-toolbox:
 
 .build:mender-dist-packages-image:
   tags:
-    - hetzner-amd-beefy-privileged
+    - k8s
   stage: build
   needs: []
   image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/docker:git


### PR DESCRIPTION
To avoid congestion issues