### PR TITLE
ci: add codecov uploader container

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -473,6 +473,18 @@ build:base-mender-go-test:
     - when: manual
       allow_failure: true
 
+build:codecov:
+  extends: .build:base-image
+  variables:
+    CONTAINER_TAG: "codecov"
+    IMAGE_NAME: "codecov"
+    BASE_IMAGE_DIR: "codecov"
+  rules:
+    - changes:
+        - codecov/Dockerfile
+    - when: manual
+      allow_failure: true
+
 .template:publish:
   stage: publish
   services:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -36,3 +36,6 @@
 
 # Goveralls
 /goveralls/ @mendersoftware/qa-dependabot-reviewers
+
+# Codecov
+/codecov/ @mendersoftware/qa-dependabot-reviewers

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ container registry as separate image repositories under `$CI_REGISTRY_IMAGE`:
 | base-ubuntu | base-ubuntu | Base Ubuntu image with common build tools and AWS CLI |
 | base-mender-cpp | base-mender-cpp | Debian-based C/C++ development environment for Mender projects |
 | aws-k8s-toolbox | aws-k8s-toolbox | Kubernetes and AWS toolbox with kubectl, Helm, kubeconform, eksctl, and yq |
+| codecov | codecov | Alpine image with the Codecov CLI for publishing coverage reports |
 | docker-multiplatform-buildx | docker-multiplatform-buildx | Docker image with git and regctl for multi-platform image management |
 | goveralls | goveralls | Go image with goveralls for code coverage reporting |
 | gui-e2e-testing | gui-e2e-testing | Playwright-based GUI end-to-end testing with mender-artifact and Docker CLI |

--- a/codecov/Dockerfile
+++ b/codecov/Dockerfile
@@ -1,0 +1,26 @@
+FROM alpine:3.24.1
+
+LABEL REFRESHED_AT=20260730
+
+ARG CODECOV_CLI_VERSION=11.0.3
+
+ARG TARGETARCH
+
+RUN apk add --no-cache \
+        ca-certificates \
+        curl \
+        git
+
+RUN case "${TARGETARCH}" in \
+        amd64) CODECOV_PLATFORM=alpine ;; \
+        arm64) CODECOV_PLATFORM=alpine-arm64 ;; \
+        *) echo "unsupported architecture: ${TARGETARCH}" && exit 1 ;; \
+    esac && \
+    curl -fsSLO "https://cli.codecov.io/v${CODECOV_CLI_VERSION}/${CODECOV_PLATFORM}/codecov" && \
+    curl -fsSLO "https://cli.codecov.io/v${CODECOV_CLI_VERSION}/${CODECOV_PLATFORM}/codecov.SHA256SUM" && \
+    sha256sum -c codecov.SHA256SUM && \
+    chmod +x codecov && \
+    mv codecov /usr/local/bin/codecov && \
+    rm codecov.SHA256SUM
+
+RUN codecov --version

--- a/renovate.json5
+++ b/renovate.json5
@@ -158,6 +158,17 @@
       "extractVersionTemplate": "^v?(?<version>.*)$",
       "versioningTemplate": "semver"
     },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/codecov\/Dockerfile/"],
+      "matchStrings": [
+        "ARG CODECOV_CLI_VERSION=(?<currentValue>[\\d\\.]+)"
+      ],
+      "depNameTemplate": "codecov/codecov-cli",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v?(?<version>.*)$",
+      "versioningTemplate": "semver"
+    },
   ],
 
   "prHourlyLimit": 0


### PR DESCRIPTION
Ships a proper `Codecov` uploader image instead of downloading the CLI at runtime into a generic curl image the CLI version is pinned and its checksum verified at build time

Ticket: [QA-1573](https://northerntech.atlassian.net/browse/QA-1573)

[QA-1573]: https://northerntech.atlassian.net/browse/QA-1573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ