### PR TITLE
ci: drop the goveralls container

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -34,8 +34,5 @@
 # Python formatting
 /python-black/ @mendersoftware/qa-dependabot-reviewers
 
-# Goveralls
-/goveralls/ @mendersoftware/qa-dependabot-reviewers
-
 # Codecov
 /codecov/ @mendersoftware/qa-dependabot-reviewers

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ container registry as separate image repositories under `$CI_REGISTRY_IMAGE`:
 | aws-k8s-toolbox | aws-k8s-toolbox | Kubernetes and AWS toolbox with kubectl, Helm, kubeconform, eksctl, and yq |
 | codecov | codecov | Alpine image with the Codecov CLI for publishing coverage reports |
 | docker-multiplatform-buildx | docker-multiplatform-buildx | Docker image with git and regctl for multi-platform image management |
-| goveralls | goveralls | Go image with goveralls for code coverage reporting |
 | gui-e2e-testing | gui-e2e-testing | Playwright-based GUI end-to-end testing with mender-artifact and Docker CLI |
 | mender-client-acceptance-testing | mender-client-acceptance-testing | Ubuntu image with Yocto/build tools, Docker, and Python for client acceptance testing |
 | mender-dist-packages-builder | mender-dist-packages-building | Multi-architecture cross-compilation image for Mender package building |

--- a/goveralls/Dockerfile
+++ b/goveralls/Dockerfile
@@ -1,7 +1,0 @@
-FROM golang:1.22-alpine3.18
-
-RUN apk add \
-      --no-cache \
-      git
-
-RUN go install github.com/mattn/goveralls@latest


### PR DESCRIPTION
integration-test-runner was the last consumer and it now uploads to codecov - cleanup

Ticket: [QA-1573](https://northerntech.atlassian.net/browse/QA-1573)

[QA-1573]: https://northerntech.atlassian.net/browse/QA-1573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ