### PR TITLE
fix: never publish mongosh-k8s-toolbox without its build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -623,8 +623,6 @@ publish:mongosh-k8s-toolbox:
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
       changes:
         - mongosh-k8s-toolbox/**/*
-    - when: manual
-      allow_failure: true
   variables:
     CONTAINER_TAG: "mongosh-k8s-v1"
     IMAGE_NAME: "mongosh-k8s-toolbox"


### PR DESCRIPTION
publish:mongosh-k8s-toolbox was the only publish job with a when: manual fallback, so it could be started on a pull request without its build. That pulls a pipeline-scoped tag which was never pushed, and on a PR branch it would target mongosh-k8s-toolbox:pr_NNNN.

Ticket: QA-1733